### PR TITLE
Zoom level support for Membership Directory

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -15,7 +15,7 @@ function pmpromm_shortcode( $atts ){
 	extract(shortcode_atts(array(
 		'height' 		=> '400', //Uses px
 		'width'			=> '100', //Uses %
-		'zoom'			=> '8',
+		'zoom'			=> apply_filters( 'pmpromm_default_zoom_level', '8' ),
 		'ID'			=> '1',
 		'infowindow_width' 	=> '300', //We'll always use px for this
 		'levels'		=> false,
@@ -489,13 +489,26 @@ function pmpromm_load_map_directory_page( $sqlQuery, $atts ){
 		'show_level' => $atts['show_level'] ,
 		'show_startdate' => $atts['show_startdate'] ,
 		'avatar_align' => $atts['avatar_align'] ,
-		'fields' => $atts['fields'] ,
+		'fields' => $atts['fields'],
+		'zoom' => isset( $atts['zoom'] ) ? $atts['zoom'] : '8'
 	);
 
 	echo pmpromm_shortcode( $attributes );
 
 }
 add_action( 'pmpro_member_directory_before', 'pmpromm_load_map_directory_page', 10, 2 );
+
+/**
+ * Adds the zoom level to the Membership Directory pages
+ */
+function pmpromm_add_zoom_level_directory_page( $atts ){
+
+	$atts['zoom'] = apply_filters( 'pmpromm_default_zoom_level', '8' ); //Must be a string to prevent any PHP errors
+
+	return $atts;
+
+}
+add_filter( 'pmpro_member_directory_before_atts', 'pmpromm_add_zoom_level_directory_page', 10, 1 );
 
 //If we're on the profile page, only show that member's marker
 function pmpromm_load_profile_map_marker( $sql_parts, $levels, $s, $pn, $limit, $start, $end ){


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Zoom level carries through to the membership directory map.

New filter added: pmpromm_default_zoom_level

Related to #24

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Zoom level supported in Membership Directory.
- New filter added `pmpromm_default_zoom_level` Useful for membership directory changes.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.