### PR TITLE
Shortcode Att ID changd to map_Id

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -16,7 +16,7 @@ function pmpromm_shortcode( $atts ){
 		'height' 		=> '400', //Uses px
 		'width'			=> '100', //Uses %
 		'zoom'			=> '8',
-		'ID'			=> '1',
+		'map_id'			=> '1',
 		'infowindow_width' 	=> '300', //We'll always use px for this
 		'levels'		=> false,
 		//Using same fields as member directory
@@ -61,11 +61,11 @@ function pmpromm_shortcode( $atts ){
 	wp_enqueue_style( 'pmpro-membership-maps-styling', plugins_url( 'css/user.css', __FILE__ ) );
 
 	/**
-	 * Setup defaults for the map. We're passing through the ID attribute
+	 * Setup defaults for the map. We're passing through the map_id attribute
 	 * to allow developers to differentiate maps. 
 	 */
-	wp_localize_script( 'pmpro-membership-maps-javascript', 'pmpromm_default_start', apply_filters( 'pmpromm_default_map_start', array( 'lat' => -34.397, 'lng' => 150.644 ), $ID ) );
-	wp_localize_script( 'pmpro-membership-maps-javascript', 'pmpromm_override_first_marker_location', apply_filters( 'pmpromm_override_first_marker', '__return_false', $ID ) );
+	wp_localize_script( 'pmpro-membership-maps-javascript', 'pmpromm_default_start', apply_filters( 'pmpromm_default_map_start', array( 'lat' => -34.397, 'lng' => 150.644 ), $map_id ) );
+	wp_localize_script( 'pmpro-membership-maps-javascript', 'pmpromm_override_first_marker_location', apply_filters( 'pmpromm_override_first_marker', '__return_false', $map_id ) );
 	wp_localize_script( 'pmpro-membership-maps-javascript', 'pmpromm_infowindow_width', $infowindow_width );
 
 	wp_localize_script( 'pmpro-membership-maps-javascript', 'pmpromm_marker_data', $marker_data );
@@ -74,7 +74,7 @@ function pmpromm_shortcode( $atts ){
 
 	wp_enqueue_script( 'pmpro-membership-maps-javascript' );
 
-	return "<div id='pmpromm_map' class='pmpromm_map pmpro_map_id_".$ID."' style='height: ".$height."px; width: ".$width."%;'>".$notice."</div>";
+	return "<div id='pmpromm_map' class='pmpromm_map pmpro_map_id_".$map_id."' style='height: ".$height."px; width: ".$width."%;'>".$notice."</div>";
 
 }
 add_shortcode( 'pmpro_membership_maps', 'pmpromm_shortcode' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

- Using the attribute ID in the shortcode causes a conflict, preventing users from changing the map ID from 1 to a chosen ID value. 

Related to #30 

### How to test the changes in this Pull Request:

1. Install Memberships Maps Add on
2. Create a page and add the shortcode [pmpro_membership_maps map_id="5"]. 5 is only an example
3. Load the page and check the source code and see that the ID is still the default "pmpromm_map pmpro_map_id_1" and not "pmpromm_map pmpro_map_id_5" as specified in shortcode attributes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- ID in shortcode attribute changed to map_ID. ID attribute is no longer supported. 
- Shortcode should now look like this [pmpro_membership_maps map_id="5"]