### PR TITLE
Update pmpro-membership-maps.php

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -142,11 +142,10 @@ function pmpromm_build_markers( $members, $marker_attributes ){
 
 	global $wpdb, $post, $pmpro_pages, $pmprorh_registration_fields;
 
-	if( !empty( $marker_attributes['show_avatar'] ) && ( 
-		$marker_attributes['show_avatar'] === "0" || 
+	if(	$marker_attributes['show_avatar'] === "0" || 
 		$marker_attributes['show_avatar'] === "false" || 
 		$marker_attributes['show_avatar'] === "no" || 
-		$marker_attributes['show_avatar'] === false ) 
+		$marker_attributes['show_avatar'] === false  
 	){
 		$show_avatar = false;
 	} else {


### PR DESCRIPTION
removed if(!empty($marker_attributes['show_avatar']) that was causing avatar to always be displayed even if disabled in shortcode. Fixes #36

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

removed if(!empty($marker_attributes['show_avatar']) that was causing avatar to always be displayed even if disabled in shortcode. Fixes #36

Closes Issue: #36.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
