### PR TITLE
Single Map Query Adjusted

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -501,9 +501,27 @@ add_action( 'pmpro_member_directory_before', 'pmpromm_load_map_directory_page', 
 function pmpromm_load_profile_map_marker( $sql_parts, $levels, $s, $pn, $limit, $start, $end ){
 
 	if( isset( $_REQUEST['pu'] ) ){
-		$member = sanitize_text_field( $_REQUEST['pu'] );
-		// $sql_parts['WHERE'] .= "AND u.user_nicename = ".sanitize_text_field( $_REQUEST['pu'] );
-		$sql_parts['WHERE'] .= "AND (u.user_login LIKE '%" . esc_sql($member) . "%' OR u.user_email LIKE '%" . esc_sql($member) . "%' OR u.display_name LIKE '%" . esc_sql($member) . "%' OR um.meta_value LIKE '%" . esc_sql($member) . "%') ";
+
+	    //Get the profile user - doing this helps when profile's nicenames look like email addresses. This caused issues in the past.
+		if(!empty($_REQUEST['pu']) && is_numeric($_REQUEST['pu']))
+			$pu = get_user_by('id', $_REQUEST['pu']);
+		elseif(!empty($_REQUEST['pu']))
+			$pu = get_user_by('slug', $_REQUEST['pu']);
+		elseif(!empty($current_user->ID))
+			$pu = $current_user;
+		else
+			$pu = false;
+				
+		unset($sql_parts['GROUP']);
+
+		if( $pu ){
+
+		    $member = sanitize_text_field( $pu->data->user_login );
+
+			$sql_parts['WHERE'] .= "AND (u.user_login LIKE '%" . esc_sql($member) . "%' OR u.user_email LIKE '%" . esc_sql($member) . "%' OR u.display_name LIKE '%" . esc_sql($member) . "%' OR um.meta_value LIKE '%" . esc_sql($member) . "%') ";
+			
+		}
+
 	}
 
 	return $sql_parts;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We now query the value present in the `pu` field to get the stored username for the user. Usernames that were generated based off of an email address returned inaccurate results or none at all in some cases. This provides a more stable solution.

### How to test the changes in this Pull Request:

1. Install the Member Directory Add On
2. Visit a single member's profile
3. The member's marker should show on the map (only theirs) without any issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Improved the single map profile page query.