### PR TITLE
Overriding starting point was ignored

### DIFF
--- a/js/user.js
+++ b/js/user.js
@@ -7,7 +7,7 @@ jQuery(document).ready(function(){
 	}
 
 	//Set your own start location for a map
-	if( pmpromm_vars.override_first_marker_location === true ){
+	if( pmpromm_vars.override_first_marker_location === "1" ){
 		var pmpromm_map_start = { lat: parseFloat( pmpromm_vars.default_start['lat'] ), lng: parseFloat( pmpromm_vars.default_start['lng'] ) };		
 	} else {
 		//If there isn't any pmpromm_markers, then use our default or override with the pmpromm_default_pmpromm_map_start filter


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We're now checking for a value of 1 instead of true if you override the starting point of the map by using a filter. 

### How to test the changes in this Pull Request:

1. This recipe will change the starting point values of the map: https://gist.github.com/JarrydLong/173a3a862f896e1f2b949e783466970c

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Bug Fix: Overriding Starting Point filter was being ignored and has now been fixed.