### PR TITLE
Show avatar attribute isn't respected from directory shortcode

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -153,7 +153,7 @@ function pmpromm_build_markers( $members, $marker_attributes ){
 
 	global $wpdb, $post, $pmpro_pages, $pmprorh_registration_fields;
 
-	if( !empty( $marker_attributes['show_avatar'] ) && ( 
+	if( isset( $marker_attributes['show_avatar'] ) && ( 
 		$marker_attributes['show_avatar'] === "0" || 
 		$marker_attributes['show_avatar'] === "false" || 
 		$marker_attributes['show_avatar'] === "no" || 


### PR DESCRIPTION
Credit to @aquiferweb for their contribution on this https://github.com/strangerstudios/pmpro-membership-maps/pull/37

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

show_avatar attribute now reflects correct value when setting it in the member directory shortcode

Closes Issue: XXX.

### How to test the changes in this Pull Request:

1. Install and activate Member Directory and Membership Maps
2. Add the shortcode to your page `[pmpro_member_directory show_avatar="no"]`
3. The avatar should no longer show on the map marker

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

show_avatar attribute works between member directory and membership map