### PR TITLE
Adjusted single profile map query

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -562,7 +562,7 @@ function pmpromm_load_profile_map_marker( $sql_parts, $levels, $s, $pn, $limit, 
 
 		if( $pu ){
 
-		    $member = sanitize_text_field( $pu->data->user_email );
+		    $member = sanitize_email( $pu->data->user_email );
 
 			$sql_parts['WHERE'] .= " AND ( u.user_email = '" . esc_sql($member) . "' ) ";
 			

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -562,9 +562,9 @@ function pmpromm_load_profile_map_marker( $sql_parts, $levels, $s, $pn, $limit, 
 
 		if( $pu ){
 
-		    $member = sanitize_text_field( $pu->data->user_login );
+		    $member = sanitize_text_field( $pu->data->user_email );
 
-			$sql_parts['WHERE'] .= "AND (u.user_login LIKE '%" . esc_sql($member) . "%' OR u.user_email LIKE '%" . esc_sql($member) . "%' OR u.display_name LIKE '%" . esc_sql($member) . "%' OR um.meta_value LIKE '%" . esc_sql($member) . "%') ";
+			$sql_parts['WHERE'] .= " AND ( u.user_email = '" . esc_sql($member) . "' ) ";
 			
 		}
 
@@ -730,7 +730,7 @@ function pmpromm_profile_url( $pu, $profile_url ) {
 		 */
 		
 		return esc_url( pmpromd_build_profile_url( (object)$pu, $profile_url ) );
-		
+
 	} else {
 		//Stick to how we've always done it
 		return add_query_arg( 'pu', $pu['user_nicename'], $profile_url );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the single profile query from a 'search' to getting a specific user.

### How to test the changes in this Pull Request:

1. Install Membership Maps
2. Install Membership Directory
3. Visit a single profile with the map enabled
4. Only that user's marker should display on the map

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Enhancement: Single map page query adjusted for a more specific result.