### PR TITLE
Geocodes an address on profile save

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -746,40 +746,57 @@ function pmpromm_profile_url( $pu, $profile_url ) {
  * @return void
  */
 function pmpro_geocode_billing_address_fields_frontend( $user_id ){
-	
+
 	if ( ! current_user_can( 'manage_options' ) ) {
 		return;
 	}
 
-	if( !function_exists( 'pmpromm_geocode_address' ) ){
+	if ( !function_exists( 'pmpromm_geocode_address' ) ){
 		return;
 	}
 
-	if( empty( $_REQUEST['billing_address_1'] ) ) {
+	if ( empty( $_REQUEST['pmpro_baddress1'] ) ) {
 		return;
 	}
 
-	$billing_address_1 = !empty( $_REQUEST['billing_address_1'] ) ? sanitize_text_field( $_REQUEST['billing_address_1'] ) : '';
+	// Get the address for each field.
+	$pmpro_baddress1 = ! empty( $_REQUEST['pmpro_baddress1'] ) ? sanitize_text_field( $_REQUEST['pmpro_baddress1'] ) : '';
+	$pmpro_baddress2 = ! empty( $_REQUEST['pmpro_baddress2'] ) ? sanitize_text_field( $_REQUEST['pmpro_baddress2'] ) : '';
+	$pmpro_bcity = ! empty( $_REQUEST['pmpro_bcity'] ) ? sanitize_text_field( $_REQUEST['pmpro_bcity'] ) : '';
+	$pmpro_bzipcode = ! empty( $_REQUEST['pmpro_bzipcode'] ) ? sanitize_text_field( $_REQUEST['pmpro_bzipcode'] ) : '';
+	$pmpro_bcountry = ! empty( $_REQUEST['pmpro_bcountry'] ) ? sanitize_text_field( $_REQUEST['pmpro_bcountry'] ) : '';
 
-	$billing_address_2 = !empty( $_REQUEST['billing_address_2'] ) ? sanitize_text_field( $_REQUEST['billing_address_2'] ) : '';
+	// If the first address is empty, bail.
+	if ( empty( $pmpro_baddress1 ) ) {
+		return;
+	}
 
 	$member_address = array(
-		'street' => $billing_address_1 . ', ' . $billing_address_2,
-		'city' => !empty( $_REQUEST['billing_city'] ) ? sanitize_text_field( $_REQUEST['billing_city'] ) : '',
-		'zip' => !empty( $_REQUEST['billing_postcode'] ) ? sanitize_text_field( $_REQUEST['billing_postcode'] ) : '',
-		'country' => !empty( $_REQUEST['billing_country'] ) ? sanitize_text_field( $_REQUEST['billing_country'] ) : ''
+		'street' => $pmpro_baddress1 . ', ' . $pmpro_baddress2,
+		'city' => $pmpro_bcity,
+		'zip' => $pmpro_bzipcode,
+		'country' => $pmpro_bcountry
 	);
 
 	/**
-	 *The billing address fields used on the profile edit pages
+	 * The billing address fields used to geocode whenever the users profile is updated and billing fields are presented.
 	 * 
-	 * @param array $member_address The array containing the address
+	 * @param array $member_address The array containing the address to geocode. See example:
+	 * 
+	 * $member_address = array(
+	 *  'street' 	=> '1313 Disneyland Drive',
+	 *	'city' 		=> 'Anaheim',
+	 *	'state' 	=> 'CA',
+	 *	'zip' 		=> '92802',
+	 *	'country'	=> 'US'
+	 * );
+	 * 
 	 */
 	$member_address = apply_filters( 'pmpromm_profile_billing_address_fields', $member_address );
 
 	$coordinates = pmpromm_geocode_address( $member_address );
 
-	if( is_array( $coordinates ) ){
+	if ( is_array( $coordinates ) ) {
 		update_user_meta( $user_id, 'pmpro_lat', floatval( $coordinates['lat'] ) );
 		update_user_meta( $user_id, 'pmpro_lng', floatval( $coordinates['lng'] ) );
 	}

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -737,3 +737,77 @@ function pmpromm_profile_url( $pu, $profile_url ) {
 	}		
 
 }
+
+/**
+ * Geocodebilling fields when saving/updating the Edit Profile page (frontend)
+ *
+ * @since TBD
+ *
+ * @return void
+ */
+function pmpro_geocode_billing_address_fields_frontend( $user_id ){
+
+	if( !function_exists( 'pmpromm_geocode_address' ) ){
+		return;
+	}
+
+	$member_address = array(
+		'street' =>  ( !empty( $_REQUEST['street_name'] ) ) ? $_REQUEST['street_name'] : get_user_meta( $user_id, 'street_name', true ),
+		'city' => ( !empty( $_REQUEST['city_name'] ) ) ? $_REQUEST['city_name'] : get_user_meta( $user_id, 'city_name', true ),
+		'zip' => ( !empty( $_REQUEST['zip_code'] ) ) ? $_REQUEST['zip_code'] : get_user_meta( $user_id, 'zip_code', true ),
+		'country' => ( !empty( $_REQUEST['country'] ) ) ? $_REQUEST['country'] : get_user_meta( $user_id, 'country', true )
+	);
+
+	/**
+	 *The billing address fields used on the profile edit pages
+	 * 
+	 * @param array $member_address The array containing the address
+	 */
+	$member_address = apply_filters( 'pmpromm_profile_billing_address_fields', $member_address );
+
+	$coordinates = pmpromm_geocode_address( $member_address );
+
+	if( is_array( $coordinates ) ){
+		update_user_meta( $user_id, 'pmpro_lat', $coordinates['lat'] );
+		update_user_meta( $user_id, 'pmpro_lng', $coordinates['lng'] );
+	}
+
+}
+add_action( 'pmpro_personal_options_update', 'pmpro_geocode_billing_address_fields_frontend', 10, 1 );
+
+/**
+ * Geocodebilling fields when saving/updating the Edit Profile page (WP Admin)
+ *
+ * @since TBD
+ *
+ * @return void
+ */
+function pmpro_geocode_billing_address_fields_profile_update(){
+
+	if( !empty( $_REQUEST['from'] ) && $_REQUEST['from'] == 'profile' ){
+
+		$member_address = array(
+			'street' =>  ( !empty( $_REQUEST['street_name'] ) ) ? $_REQUEST['street_name'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'street_name', true ),
+			'city' => ( !empty( $_REQUEST['city_name'] ) ) ? $_REQUEST['city_name'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'city_name', true ),
+			'zip' => ( !empty( $_REQUEST['zip_code'] ) ) ? $_REQUEST['zip_code'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'zip_code', true ),
+			'country' => ( !empty( $_REQUEST['country'] ) ) ? $_REQUEST['country'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'country', true )
+		);
+
+		/**
+		 * The billing address fields used on the profile edit pages
+		 * 
+		 * @param array $member_address The array containing the address
+		 */
+		$member_address = apply_filters( 'pmpromm_profile_billing_address_fields', $member_address );
+
+		$coordinates = pmpromm_geocode_address( $member_address );
+
+		if( is_array( $coordinates ) ){
+			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lat', $coordinates['lat'] );
+			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lng', $coordinates['lng'] );
+		}
+
+	}
+
+}
+add_action( 'admin_init', 'pmpro_geocode_billing_address_fields_profile_update' );

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -739,23 +739,35 @@ function pmpromm_profile_url( $pu, $profile_url ) {
 }
 
 /**
- * Geocodebilling fields when saving/updating the Edit Profile page (frontend)
+ * Geocodebilling fields when saving/updating a user profile
  *
  * @since TBD
  *
  * @return void
  */
 function pmpro_geocode_billing_address_fields_frontend( $user_id ){
+	
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return;
+	}
 
 	if( !function_exists( 'pmpromm_geocode_address' ) ){
 		return;
 	}
 
+	if( empty( $_REQUEST['billing_address_1'] ) ) {
+		return;
+	}
+
+	$billing_address_1 = !empty( $_REQUEST['billing_address_1'] ) ? sanitize_text_field( $_REQUEST['billing_address_1'] ) : '';
+
+	$billing_address_2 = !empty( $_REQUEST['billing_address_2'] ) ? sanitize_text_field( $_REQUEST['billing_address_2'] ) : '';
+
 	$member_address = array(
-		'street' =>  !empty( $_REQUEST['street_name'] ) ? sanitize_text_field( $_REQUEST['street_name'] ) : get_user_meta( $user_id, 'street_name', true ),
-		'city' => !empty( $_REQUEST['city_name'] ) ? sanitize_text_field( $_REQUEST['city_name'] ) : get_user_meta( $user_id, 'city_name', true ),
-		'zip' => !empty( $_REQUEST['zip_code'] ) ? sanitize_text_field( $_REQUEST['zip_code'] ) : get_user_meta( $user_id, 'zip_code', true ),
-		'country' => !empty( $_REQUEST['country'] ) ? sanitize_text_field( $_REQUEST['country'] ) : get_user_meta( $user_id, 'country', true )
+		'street' => $billing_address_1 . ', ' . $billing_address_2,
+		'city' => !empty( $_REQUEST['billing_city'] ) ? sanitize_text_field( $_REQUEST['billing_city'] ) : '',
+		'zip' => !empty( $_REQUEST['billing_postcode'] ) ? sanitize_text_field( $_REQUEST['billing_postcode'] ) : '',
+		'country' => !empty( $_REQUEST['billing_country'] ) ? sanitize_text_field( $_REQUEST['billing_country'] ) : ''
 	);
 
 	/**
@@ -774,40 +786,5 @@ function pmpro_geocode_billing_address_fields_frontend( $user_id ){
 
 }
 add_action( 'pmpro_personal_options_update', 'pmpro_geocode_billing_address_fields_frontend', 10, 1 );
-
-/**
- * Geocodebilling fields when saving/updating the Edit Profile page (WP Admin)
- *
- * @since TBD
- *
- * @return void
- */
-function pmpro_geocode_billing_address_fields_profile_update(){
-
-	if( !empty( $_REQUEST['from'] ) && $_REQUEST['from'] == 'profile' ){
-
-		$member_address = array(
-			'street' =>  !empty( $_REQUEST['street_name'] ) ? sanitize_text_field( $_REQUEST['street_name'] ) : get_user_meta( $user_id, 'street_name', true ),
-			'city' => !empty( $_REQUEST['city_name'] ) ? sanitize_text_field( $_REQUEST['city_name'] ) : get_user_meta( $user_id, 'city_name', true ),
-			'zip' => !empty( $_REQUEST['zip_code'] ) ? sanitize_text_field( $_REQUEST['zip_code'] ) : get_user_meta( $user_id, 'zip_code', true ),
-			'country' => !empty( $_REQUEST['country'] ) ? sanitize_text_field( $_REQUEST['country'] ) : get_user_meta( $user_id, 'country', true )
-		);
-
-		/**
-		 * The billing address fields used on the profile edit pages
-		 * 
-		 * @param array $member_address The array containing the address
-		 */
-		$member_address = apply_filters( 'pmpromm_profile_billing_address_fields', $member_address );
-
-		$coordinates = pmpromm_geocode_address( $member_address );
-
-		if( is_array( $coordinates ) ){
-			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lat', floatval( $coordinates['lat'] ) );
-			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lng', floatval( $coordinates['lng'] ) );
-		}
-
-	}
-
-}
-add_action( 'admin_init', 'pmpro_geocode_billing_address_fields_profile_update' );
+add_action( 'personal_options_update', 'pmpro_geocode_billing_address_fields_frontend', 10, 1 );
+add_action( 'edit_user_profile_update', 'pmpro_geocode_billing_address_fields_frontend', 10, 1 );

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -784,7 +784,7 @@ function pmpro_geocode_billing_address_fields_frontend( $user_id ){
 	 * @param array $member_address The array containing the address to geocode. See example:
 	 * 
 	 * $member_address = array(
-	 *  'street' 	=> '1313 Disneyland Drive',
+	 *	'street' 	=> '1313 Disneyland Drive',
 	 *	'city' 		=> 'Anaheim',
 	 *	'state' 	=> 'CA',
 	 *	'zip' 		=> '92802',

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -752,10 +752,10 @@ function pmpro_geocode_billing_address_fields_frontend( $user_id ){
 	}
 
 	$member_address = array(
-		'street' =>  ( !empty( $_REQUEST['street_name'] ) ) ? $_REQUEST['street_name'] : get_user_meta( $user_id, 'street_name', true ),
-		'city' => ( !empty( $_REQUEST['city_name'] ) ) ? $_REQUEST['city_name'] : get_user_meta( $user_id, 'city_name', true ),
-		'zip' => ( !empty( $_REQUEST['zip_code'] ) ) ? $_REQUEST['zip_code'] : get_user_meta( $user_id, 'zip_code', true ),
-		'country' => ( !empty( $_REQUEST['country'] ) ) ? $_REQUEST['country'] : get_user_meta( $user_id, 'country', true )
+		'street' =>  !empty( $_REQUEST['street_name'] ) ? sanitize_text_field( $_REQUEST['street_name'] ) : get_user_meta( $user_id, 'street_name', true ),
+		'city' => !empty( $_REQUEST['city_name'] ) ? sanitize_text_field( $_REQUEST['city_name'] ) : get_user_meta( $user_id, 'city_name', true ),
+		'zip' => !empty( $_REQUEST['zip_code'] ) ? sanitize_text_field( $_REQUEST['zip_code'] ) : get_user_meta( $user_id, 'zip_code', true ),
+		'country' => !empty( $_REQUEST['country'] ) ? sanitize_text_field( $_REQUEST['country'] ) : get_user_meta( $user_id, 'country', true )
 	);
 
 	/**
@@ -768,8 +768,8 @@ function pmpro_geocode_billing_address_fields_frontend( $user_id ){
 	$coordinates = pmpromm_geocode_address( $member_address );
 
 	if( is_array( $coordinates ) ){
-		update_user_meta( $user_id, 'pmpro_lat', $coordinates['lat'] );
-		update_user_meta( $user_id, 'pmpro_lng', $coordinates['lng'] );
+		update_user_meta( $user_id, 'pmpro_lat', floatval( $coordinates['lat'] ) );
+		update_user_meta( $user_id, 'pmpro_lng', floatval( $coordinates['lng'] ) );
 	}
 
 }
@@ -787,10 +787,10 @@ function pmpro_geocode_billing_address_fields_profile_update(){
 	if( !empty( $_REQUEST['from'] ) && $_REQUEST['from'] == 'profile' ){
 
 		$member_address = array(
-			'street' =>  ( !empty( $_REQUEST['street_name'] ) ) ? $_REQUEST['street_name'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'street_name', true ),
-			'city' => ( !empty( $_REQUEST['city_name'] ) ) ? $_REQUEST['city_name'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'city_name', true ),
-			'zip' => ( !empty( $_REQUEST['zip_code'] ) ) ? $_REQUEST['zip_code'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'zip_code', true ),
-			'country' => ( !empty( $_REQUEST['country'] ) ) ? $_REQUEST['country'] : get_user_meta( intval( $_REQUEST['user_id'] ), 'country', true )
+			'street' =>  !empty( $_REQUEST['street_name'] ) ? sanitize_text_field( $_REQUEST['street_name'] ) : get_user_meta( $user_id, 'street_name', true ),
+			'city' => !empty( $_REQUEST['city_name'] ) ? sanitize_text_field( $_REQUEST['city_name'] ) : get_user_meta( $user_id, 'city_name', true ),
+			'zip' => !empty( $_REQUEST['zip_code'] ) ? sanitize_text_field( $_REQUEST['zip_code'] ) : get_user_meta( $user_id, 'zip_code', true ),
+			'country' => !empty( $_REQUEST['country'] ) ? sanitize_text_field( $_REQUEST['country'] ) : get_user_meta( $user_id, 'country', true )
 		);
 
 		/**
@@ -803,8 +803,8 @@ function pmpro_geocode_billing_address_fields_profile_update(){
 		$coordinates = pmpromm_geocode_address( $member_address );
 
 		if( is_array( $coordinates ) ){
-			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lat', $coordinates['lat'] );
-			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lng', $coordinates['lng'] );
+			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lat', floatval( $coordinates['lat'] ) );
+			update_user_meta( intval( $_REQUEST['user_id'] ), 'pmpro_lng', floatval( $coordinates['lng'] ) );
 		}
 
 	}

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -742,8 +742,6 @@ function pmpromm_profile_url( $pu, $profile_url ) {
  * Geocodebilling fields when saving/updating a user profile
  *
  * @since TBD
- *
- * @return void
  */
 function pmpro_geocode_billing_address_fields_frontend( $user_id ){
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Geocodes billing address fields when saving a profile in wp-admin and the front end profile edit page

Resolves #48 

### How to test the changes in this Pull Request:

1. Ensure that billing fields are present on the profile edit pge
2. Change the address to a new location
3. Hit the save button. The new address should show on the map
4. New filter added to change address fields in the event of custom fields being used `pmpromm_profile_billing_address_fields`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Enhancement: Billing address fields are now geocoded on profile save. 