### PR TITLE
Spacing added below map

### DIFF
--- a/css/user.css
+++ b/css/user.css
@@ -2,3 +2,7 @@
 .pmpromm_infowindow p{
 	margin: 4px 0 8px 0;
 }
+
+.pmpromm_map {
+    margin-bottom: 2%;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds some spacing at the bottom of the map so that it doesn't touch the directory container

### How to test the changes in this Pull Request:

1. Install Membership Maps and Directory
2. Visit the directory page. Map was previously touching the directory listings below it. 
3. Spacing has been added so that they don't touch
4. This is needed after doing this PR https://github.com/strangerstudios/pmpro-member-directory/pull/123/files

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Enhancement: Minor spacing added between map and directory container.