### PR TITLE
Allows you to test an API key from the settings page

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -456,8 +456,7 @@ function pmpromm_advanced_settings_field( $fields ) {
 
 	if( defined( 'PMPRO_VERSION' ) ){
 		if( version_compare( PMPRO_VERSION, '2.4.2', '>=' ) ){
-
-			$fields['pmpromm_api_key']['description'] = sprintf( __( 'Used by the Membership Maps Add On. %s %s', 'pmpro-membership-maps' ), '<a href="https://www.paidmembershipspro.com/add-ons/membership-maps/#google-maps-api-key" target="_BLANK">'.__( 'Obtain Your Google Maps API Key', 'pmpro-membership-maps' ).'</a>', __( 'API Key Status', 'pmpro-membership-maps' ).': '.pmpro_getOption( 'pmpromm_api_key_status' ) );
+			$fields['pmpromm_api_key']['description'] = sprintf( __( 'Used by the Membership Maps Add On. %s %s', 'pmpro-membership-maps' ), '<a href="https://www.paidmembershipspro.com/add-ons/membership-maps/#google-maps-api-key" target="_BLANK">' . __( 'Obtain Your Google Maps API Key', 'pmpro-membership-maps' ).'</a>', '<br/><code>' . __( 'API Key Status', 'pmpro-membership-maps' ).': ' . pmpro_getOption( 'pmpromm_api_key_status' ) ) . '</code>';
 		}
 	}
 
@@ -479,8 +478,9 @@ function pmpromm_test_api_key() {
 		$new_key = trim( sanitize_text_field( $_REQUEST['pmpromm_api_key'] ) );
 
 		$api_key_status = pmpro_getOption( 'pmpromm_api_key_status' );
-		//API Key has changed, lets test if it works
-		if( $new_key !== $current_key || empty( $api_key_status ) ) {
+
+		//API key differs or the status is not OK, let's test the key.
+		if ( $new_key !== $current_key || $api_key_status !== 'OK' ) {
 
 			/**
 			 * This is a sample address used to test if the API key entered works as expected. 
@@ -498,7 +498,8 @@ function pmpromm_test_api_key() {
 			if( $geocoded_result->status == 'OK' ) {
 				pmpro_setOption( 'pmpromm_api_key_status', 'OK' );				
 			} else {
-				pmpro_setOption( 'pmpromm_api_key_status', $geocoded_result->status.' '.$geocoded_result->error_message );				
+				$status = sanitize_text_field( $geocoded_result->status . ' ' . $geocoded_result->error_message );
+				pmpro_setOption( 'pmpromm_api_key_status', $status );
 			}			
 				
 
@@ -536,7 +537,7 @@ function pmpromm_sitehealth_information( $fields ) {
 
 	$map_data = array( 'pmpromm-api-key-status' => array(
 		'label' => __( 'Membership Maps API Key Status', 'paid-memberships-pro' ),
-		'value' => pmpro_getOption( 'pmpromm_api_key_status' ),
+		'value' => esc_html( pmpro_getOption( 'pmpromm_api_key_status' ) ),
 	) );
 
 	$fields['pmpro']['fields'] = array_merge( $fields['pmpro']['fields'], $map_data );

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -476,10 +476,11 @@ function pmpromm_test_api_key() {
 
 		$current_key = pmpro_getOption( 'pmpromm_api_key' );
 
-		$new_key = sanitize_text_field( $_REQUEST['pmpromm_api_key'] );
+		$new_key = trim( sanitize_text_field( $_REQUEST['pmpromm_api_key'] ) );
 
+		$api_key_status = pmpro_getOption( 'pmpromm_api_key_status' );
 		//API Key has changed, lets test if it works
-		if( $new_key !== $current_key ) {
+		if( $new_key !== $current_key || empty( $api_key_status ) ) {
 
 			/**
 			 * This is a sample address used to test if the API key entered works as expected. 
@@ -493,7 +494,6 @@ function pmpromm_test_api_key() {
 			
 			add_filter( 'pmpromm_geocoding_api_key', 'pmpromm_use_api_key_on_save' );
 			$geocoded_result = pmpromm_geocode_address( $member_address, false, true );
-			remove_filter( 'pmpromm_geocoding_api_key', 'pmpromm_use_api_key_on_save' );
 			
 			if( $geocoded_result->status == 'OK' ) {
 				pmpro_setOption( 'pmpromm_api_key_status', 'OK' );				
@@ -517,7 +517,7 @@ add_action( 'admin_init', 'pmpromm_test_api_key' );
 function pmpromm_use_api_key_on_save( $api_key ) {
 
 	if ( ! empty( $_REQUEST['pmpromm_api_key'] ) ) {
-		$api_key = sanitize_text_field( $_REQUEST['pmpromm_api_key'] );
+		$api_key = trim( sanitize_text_field( $_REQUEST['pmpromm_api_key'] ) );
 	}
 
 	return $api_key;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows you to test if the API key that has been entered will be able to interact with the Google Maps API as expected

Closes Issue: XXX.

### How to test the changes in this Pull Request:

1. Go to Memberships > Settings > Advanced and enter in your API key
2. Once saved, click on the 'Test API Key' link below the API key you've entered
3. A new window will open with the test result from the Google Maps API

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added in the functionality to test a Google Maps API key after saving