### PR TITLE
Adds support for max zoom level

### DIFF
--- a/js/user.js
+++ b/js/user.js
@@ -20,9 +20,12 @@ jQuery(document).ready(function(){
 		}
 	}
 	
+
+
 	var pmpromm_map_arguments = {
 		center: pmpromm_map_start,
-		zoom: parseInt( pmpromm_vars.zoom_level )
+		zoom: parseInt( pmpromm_vars.zoom_level ),
+		maxZoom: pmpromm_vars.max_zoom
 	};
 
 	//Initiating the map

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -16,6 +16,7 @@ function pmpromm_shortcode( $atts ){
 		'height' 		=> '400', //Uses px
 		'width'			=> '100', //Uses %
 		'zoom'			=> apply_filters( 'pmpromm_default_zoom_level', '8' ),
+		'max_zoom' 		=> NULL,
 		'map_id'			=> '1',
 		'infowindow_width' 	=> '300', //We'll always use px for this
 		'levels'		=> false,
@@ -78,6 +79,7 @@ function pmpromm_shortcode( $atts ){
 		'infowindow_width' => $infowindow_width,
 		'marker_data' => $marker_data,
 		'zoom_level' => $zoom,
+		'max_zoom' => $max_zoom,
 		'infowindow_classes' => pmpromm_get_element_class( 'pmpromm_infowindow' ),
 		'map_styles' => $map_styles		
 	) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves #67 

### How to test the changes in this Pull Request:

1. Update your shortcode to use the max_zoom shortcode attribute [pmpro_membership_maps max_zoom='10']
2. Try zooming further into your map, it will only allow you to zoom up to a point.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

