### PR TITLE
Adds Member Directory Support for Limits

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -28,7 +28,8 @@ function pmpromm_shortcode( $atts ){
 		'show_level' 	=> true,
 		'show_startdate' => true,
 		'avatar_align' 	=> NULL,
-		'fields' 		=> NULL
+		'fields' 		=> NULL,
+		'limit' 		=> 100,
 	), $atts));
 
 	$marker_attributes = apply_filters( 'pmpromm_marker_attributes', array(
@@ -45,7 +46,8 @@ function pmpromm_shortcode( $atts ){
 	$notice = apply_filters( 'pmpromm_default_map_notice', __( 'This map could not be loaded. Please ensure that you have entered your Google Maps API Key and that there are no JavaScript errors on the page.', 'pmpro-membership-maps' ) );
 
 	$start = apply_filters( 'pmpromm_load_markers_start', 0, $levels, $marker_attributes );
-	$limit = apply_filters( 'pmpromm_load_markers_limit', 100, $levels, $marker_attributes );
+	$limit = apply_filters( 'pmpromm_load_markers_limit', $limit, $levels, $marker_attributes );
+
 	//Get the marker data
 	$marker_data = pmpromm_load_marker_data( $levels, $marker_attributes, $start, $limit );
 
@@ -635,7 +637,8 @@ function pmpromm_load_map_directory_page( $sqlQuery, $atts ){
 		'show_startdate' => $atts['show_startdate'] ,
 		'avatar_align' => $atts['avatar_align'] ,
 		'fields' => $atts['fields'],
-		'zoom' => isset( $atts['zoom'] ) ? $atts['zoom'] : '8'
+		'zoom' => isset( $atts['zoom'] ) ? $atts['zoom'] : '8',
+		'limit' => isset( $atts['limit'] ) ? $atts['limit'] : '100',
 	);
 
 	echo pmpromm_shortcode( $attributes );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Membership maps are automatically added to a directory page when active.

We assume that when adding a limit attribute to the Membership Directory shortcode, that it should apply to the membership map's query as well. 

A limit attribute has been added to the membership map shortcode and the directory shortcode now applies the same limit to the map if present.


### How to test the changes in this Pull Request:

1. Install and activate Membership Maps and Membership Directory
2. Add the shortcode `[pmpro_member_directory limit=209]` to a page
3. Changing the limit will apply to the number of Map markers shown as well

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
