### PR TITLE
Deprecated Billing Preheader Function

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -458,6 +458,8 @@ add_action( 'pmpro_after_checkout', 'pmpromm_after_checkout', 10, 2 );
 
 function pmpromm_update_billing_info( $morder ){
 
+    _deprecated_function( __FUNCTION__, 'TBD' );
+
 	global $current_user;
 
 	if( !empty( $_REQUEST['baddress1'] ) ){
@@ -482,7 +484,7 @@ function pmpromm_update_billing_info( $morder ){
 	}
 
 }
-add_action( 'pmpro_billing_after_preheader', 'pmpromm_update_billing_info', 10, 1 );
+// add_action( 'pmpro_billing_after_preheader', 'pmpromm_update_billing_info', 10, 1 );
 
 //Adds API Key field to advanced settings page
 function pmpromm_advanced_settings_field( $fields ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Deprecates billing address preheader function

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

