### PR TITLE
[bugfixing] Viewing own Directory Profile shows multiple markers 

### DIFF
--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -662,45 +662,60 @@ function pmpromm_add_zoom_level_directory_page( $atts ){
 }
 add_filter( 'pmpro_member_directory_before_atts', 'pmpromm_add_zoom_level_directory_page', 10, 1 );
 
-//If we're on the profile page, only show that member's marker
-function pmpromm_load_profile_map_marker( $sql_parts, $levels, $s, $pn, $limit, $start, $end ){
+/**
+ * pmpro_membership_maps_sql_parts filter function callback. Let you edit the SQL parts array before the query is run.
+ * This one specifically try to determine if should load the map marker for a profile page.
+ *
+ * @param string $sql_parts The SQL parts array
+ * @param array $levels The levels array
+ * @param string $s The search string
+ * @param string $pn The page number
+ * @param int $limit The limit
+ * @param int $start The start
+ * @param int $end The end
+ * @return string The SQL parts array
+ * @since TBD
+ */
+function pmpromm_load_profile_map_marker( $sql_parts, $levels, $s, $pn, $limit, $start, $end ) {
+    global $wp_query, $pmpro_pages;
 
-	global $wp_query;
+    $pu = "";
+    if( !empty( $wp_query->get( 'pu' ) ) ) {
+        $pu = sanitize_text_field( $wp_query->get( 'pu' ) );
+    } else if( !empty( $_REQUEST['pu'] ) ) {
+        $pu = sanitize_text_field( $_REQUEST['pu'] );
+    } else if ( is_page( $pmpro_pages['profile']) ) {
+       $pu = wp_get_current_user();
+    }
 
-	if( !empty( $wp_query->get( 'pu' ) ) ) {
-		$pu = sanitize_text_field( $wp_query->get( 'pu' ) );
-	} else { 
-		if( !empty( $_REQUEST['pu'] ) ) {
-			$pu = sanitize_text_field( $_REQUEST['pu'] );
-		}
-	}
+	//If we don't have a profile user, return the SQL parts
+    if( empty( $pu ) ) {
+        return $sql_parts;
+    }
 
-	if( !empty( $pu ) ){
+    $user_by_pu = null;
+    //Get the profile user - doing this helps when profile's nicenames look like email addresses. This caused issues in the past.
+    if( is_numeric( $pu ) ) {
+        $user_by_pu = get_user_by('id',  $pu );
+	//determine if it's a wp user object
+	} else if( is_a( $pu, 'WP_User' ) ) {
+		$user_by_pu = $pu;
+	} else {
+        $user_by_pu = get_user_by('slug',  $pu );
+    }
 
-	    //Get the profile user - doing this helps when profile's nicenames look like email addresses. This caused issues in the past.
-		if( !empty( $pu ) && is_numeric( $pu ) ) {
-			$pu = get_user_by('id',  $pu );
-		} elseif( !empty( $pu ) ) {
-			$pu = get_user_by('slug',  $pu );
-		} elseif( !empty( $current_user->ID ) ) {
-			$pu = $current_user;
-		} else {
-			$pu = false;		
-		}
+	//If we don't have a user, return the SQL parts
+    if( empty( $user_by_pu ) ) {
+        return $sql_parts;
+    }
 
-		if( $pu ){
+    $member = sanitize_email( $user_by_pu->data->user_email );
+    $sql_parts['WHERE'] .= " AND ( u.user_email = '" . esc_sql( $member ) . "' ) ";
 
-		    $member = sanitize_email( $pu->data->user_email );
-
-			$sql_parts['WHERE'] .= " AND ( u.user_email = '" . esc_sql($member) . "' ) ";
-			
-		}
-
-	}
-
-	return $sql_parts;
+    return $sql_parts;
 
 }
+
 add_filter( 'pmpro_membership_maps_sql_parts', 'pmpromm_load_profile_map_marker', 10, 7 );
 
 //Adds the map to the profile page

--- a/pmpro-membership-maps.php
+++ b/pmpro-membership-maps.php
@@ -663,7 +663,7 @@ function pmpromm_add_zoom_level_directory_page( $atts ){
 add_filter( 'pmpro_member_directory_before_atts', 'pmpromm_add_zoom_level_directory_page', 10, 1 );
 
 /**
- * Load the member's single marker when viewing the Membership Directory Profile Page or if a specific `pu` value is set.
+ * Load the member's single marker when viewing the Membership Directory Profile Page.
  */
 function pmpromm_load_profile_map_marker( $sql_parts, $levels, $s, $pn, $limit, $start, $end ) {
 	global $wp_query, $pmpro_pages;


### PR DESCRIPTION
 * tweak pmpromm_load_profile_map_marker function to narrow sql select whene PU isn't passed in the URL.

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/a73ef4c3-52f8-4bdf-9ea1-bcac831b094e" />


### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

tweak pmpromm_load_profile_map_marker function to narrow sql select whene PU isn't passed in the URL. Basically if PU isn't passed from $wp_query or the request and yet is the profile page we assume it's own profile page.

Closes Issue:  #87 

### How to test the changes in this Pull Request:

Follow steps described in issue above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.