### PR TITLE
Prevents a fatal error from occuring when PMPro core is inactive

### DIFF
--- a/includes/pmpro-class-member-edit-panel-map-address.php
+++ b/includes/pmpro-class-member-edit-panel-map-address.php
@@ -6,6 +6,7 @@
  * @since 0.8
  */
 
+//If PMPro core is in active or the class doesn't exist, bail.
 if( ! class_exists( 'PMPro_Member_Edit_Panel' ) ) {
     return;
 }

--- a/includes/pmpro-class-member-edit-panel-map-address.php
+++ b/includes/pmpro-class-member-edit-panel-map-address.php
@@ -5,6 +5,11 @@
  *
  * @since 0.8
  */
+
+if( ! class_exists( 'PMPro_Member_Edit_Panel' ) ) {
+    return;
+}
+
 class PMPro_Member_Edit_Panel_Map_Address extends PMPro_Member_Edit_Panel {
 	/**
 	 * Set up the panel.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Checks if the `PMPro_Member_Edit_Panel` class exists before trying to extend it

### How to test the changes in this Pull Request:

1. Activate PMPro core + Membership Maps
2. Deactivate PMPro core
3. No fatal errors should occur

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
